### PR TITLE
Zladx theft count

### DIFF
--- a/src/lib/templates/legend-of-zelda-the-link-s-awakening-dx-gbc/saveEditor/template.ts
+++ b/src/lib/templates/legend-of-zelda-the-link-s-awakening-dx-gbc/saveEditor/template.ts
@@ -500,6 +500,7 @@ const template: GameJson = {
                               type: "variable",
                               dataType: "uint8",
                               max: 26,
+                              binaryCodedDecimal: true,
                             },
                             {
                               name: "Golden Leaves / Slime Key",

--- a/src/lib/templates/legend-of-zelda-the-link-s-awakening-dx-gbc/saveEditor/template.ts
+++ b/src/lib/templates/legend-of-zelda-the-link-s-awakening-dx-gbc/saveEditor/template.ts
@@ -112,6 +112,12 @@ const template: GameJson = {
                           dataType: "uint8",
                           binaryCodedDecimal: true,
                         },
+                        {
+                          name: "Theft Count",
+                          offset: 0x473,
+                          type: "variable",
+                          dataType: "uint8",
+                        },
                       ],
                     },
                     {


### PR DESCRIPTION
If you steal items from the shop,  wIsThief and wHasStolenFromShop in WRAM are increased. NPC like Marin will start calling you a thief because wIsThief > 0. If you go back into the shop after you’ve stolen something, the shop-keeper will zap you with an electric shock, killing you instantly because wHasStolenFromShop > 0 and then reset wHasStolenFromShop to 0.

![Legend of Zelda, The - Link's Awakening DX (USA, Europe) (Rev 2) (SGB Enhanced) (GB Compatible)-0](https://github.com/user-attachments/assets/88bc81d4-67d8-4431-9fc4-6d59ba226dbf)

Once you save, wIsThief is saved 0x473 and  wHasStolenFromShop is to 0x44a. wHasStolenFromShop can be reset by losing one life (increasing one death count) so there is no need to modify it. But we need to reset wIsThief so that our heroine can be nice to us again, XD

Funny fact:
wIsThief is a count instead of a boolean. If the count is 0xFF (255) and you steal again, count becomes 0 due to overflow. Marin stops calling you a thief. Basically, you become a thief and have no way to modify save, then you can steal 255 times and you can get rid of that title, XD 


